### PR TITLE
Fixes and feats

### DIFF
--- a/pkg/binman.go
+++ b/pkg/binman.go
@@ -107,10 +107,18 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 
 	// untar file
 	if isTar(filePath) {
-		log.Debug("extract start")
+		log.Debug("tar extract start")
 		err = handleTar(rel.PublishPath, filePath)
 		if err != nil {
-			log.Warnf("Failed to extract file : %v", err)
+			log.Warnf("Failed to extract tar file: %v", err)
+			c <- BinmanMsg{rel: rel, err: err}
+			return
+		}
+	} else if isZip(filePath) {
+		log.Debug("zip extract start")
+		err = handleZip(rel.PublishPath, filePath)
+		if err != nil {
+			log.Warnf("Failed to extract zip file: %v", err)
 			c <- BinmanMsg{rel: rel, err: err}
 			return
 		}

--- a/pkg/binman.go
+++ b/pkg/binman.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/google/go-github/v44/github"
@@ -17,7 +18,8 @@ const timeout = 60 * time.Second
 
 var log = logrus.New()
 
-func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, c chan error) {
+func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, c chan<- BinmanMsg, wg *sync.WaitGroup) {
+	defer wg.Done()
 
 	var assetName, dlUrl string
 	var err error
@@ -37,7 +39,7 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 
 	if err != nil {
 		log.Warnf("error listing releases %v", err)
-		c <- err
+		c <- BinmanMsg{rel: rel, err: err}
 		return
 	}
 
@@ -48,7 +50,7 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 		_, err = os.Stat(rel.PublishPath)
 		if err == nil {
 			log.Infof("Latest version is %s %s is up to date", *rel.GithubData.TagName, rel.Repo)
-			c <- err
+			c <- BinmanMsg{rel: rel, err: err}
 			return
 		}
 	}
@@ -70,7 +72,7 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 
 	if dlUrl == "" {
 		log.Warnf("Target release asset not found for %s", rel.Repo)
-		c <- err
+		c <- BinmanMsg{rel: rel, err: nil}
 		return
 	}
 
@@ -83,7 +85,7 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 	err = os.MkdirAll(rel.PublishPath, 0750)
 	if err != nil {
 		log.Warnf("Error creating %s - %v", rel.PublishPath, err)
-		c <- err
+		c <- BinmanMsg{rel: rel, err: err}
 		return
 	}
 
@@ -93,13 +95,13 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 	err = downloadFile(filePath, dlUrl)
 	if err != nil {
 		log.Warnf("Unable to download file : %v", err)
-		c <- err
+		c <- BinmanMsg{rel: rel, err: err}
 		return
 	}
 
 	// If user has requested download only move to next release
 	if rel.DownloadOnly {
-		c <- err
+		c <- BinmanMsg{rel: rel, err: err}
 		return
 	}
 
@@ -109,7 +111,7 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 		err = handleTar(rel.PublishPath, filePath)
 		if err != nil {
 			log.Warnf("Failed to extract file : %v", err)
-			c <- err
+			c <- BinmanMsg{rel: rel, err: err}
 			return
 		}
 	}
@@ -118,7 +120,7 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 	err = os.Chmod(rel.ArtifactPath, 0750)
 	if err != nil {
 		log.Warnf("Failed to set permissions on %s", rel.PublishPath)
-		c <- err
+		c <- BinmanMsg{rel: rel, err: err}
 		return
 	}
 
@@ -126,7 +128,7 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 	err = createReleaseLink(rel.ArtifactPath, rel.LinkPath)
 	if err != nil {
 		log.Warnf("Failed to make symlink: %v", err)
-		c <- err
+		c <- BinmanMsg{rel: rel, err: err}
 		return
 	}
 
@@ -134,7 +136,7 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 	_, err = os.Stat(rel.LinkPath)
 	if err != nil {
 		log.Warnf("Issue with created symlink: %v", err)
-		c <- err
+		c <- BinmanMsg{rel: rel, err: err}
 		return
 	}
 	log.Debugf("Symlink Created!")
@@ -146,13 +148,13 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 		err := writeNotes(notePath, relNotes)
 		if err != nil {
 			log.Fatalf("Issue writing release notes: %v", err)
-			c <- err
+			c <- BinmanMsg{rel: rel, err: err}
 			return
 		}
 		log.Debugf("Notes written to %s", notePath)
 	}
 
-	c <- nil
+	c <- BinmanMsg{rel: rel, err: nil}
 	return
 }
 
@@ -174,32 +176,28 @@ func Main(work map[string]string, debug bool, jsonLog bool) {
 
 	log.Info("binman sync begin")
 
-	c := make(chan error)
+	c := make(chan BinmanMsg)
+	var wg sync.WaitGroup
+	var releases []BinmanRelease
+	var ghClient *github.Client
+	var releasePath string
 
 	if work["configFile"] != "" {
 		log.Debug("config sync")
 		config := newGHBMConfig(work["configFile"])
-
-		log.Debugf("Process %v Releases", len(config.Releases))
-
-		ghClient := gh.GetGHCLient(config.Config.TokenVar)
-
 		log.Debugf("config = %+v", config)
 
-		// https://github.com/lotusirous/go-concurrency-patterns/blob/main/2-chan/main.go
-		for _, rel := range config.Releases {
-			go goSyncRepo(ghClient, config.Config.ReleasePath, rel, c)
-		}
+		releases = config.Releases
+		log.Debugf("Process %v Releases", len(releases))
+		releasePath = config.Config.ReleasePath
 
-		for _, rel := range config.Releases {
-			log.Debugf("Repo %s, Error %q\n", rel.Repo, <-c)
-		}
-
+		ghClient = gh.GetGHCLient(config.Config.TokenVar)
 	} else {
+		var err error
 		log.Info("direct repo download")
-		ghClient := gh.GetGHCLient("none")
+		ghClient = gh.GetGHCLient("none")
 
-		cdir, err := os.Getwd()
+		releasePath, err = os.Getwd()
 		if err != nil {
 			log.Fatal("Unable to get current working directory")
 		}
@@ -208,18 +206,31 @@ func Main(work map[string]string, debug bool, jsonLog bool) {
 			Repo:         work["repo"],
 			Os:           runtime.GOOS,
 			Arch:         runtime.GOARCH,
-			PublishPath:  cdir,
+			PublishPath:  releasePath,
 			DownloadOnly: true,
 			Version:      work["version"],
 		}
 
 		rel.getOR()
 
-		go goSyncRepo(ghClient, cdir, rel, c)
-		for i := 0; i < 1; i++ {
-			log.Debugf("Repo %s, Error %q\n", rel.Repo, <-c)
-		}
+		releases = []BinmanRelease{rel}
+	}
 
+	// https://github.com/lotusirous/go-concurrency-patterns/blob/main/2-chan/main.go
+	for _, rel := range releases {
+		wg.Add(1)
+		go goSyncRepo(ghClient, releasePath, rel, c, &wg)
+	}
+
+	go func(c chan BinmanMsg, wg *sync.WaitGroup) {
+		wg.Wait()
+		close(c)
+	}(c, &wg)
+
+	for msg := range c {
+		if msg.err != nil {
+			log.Debugf("Repo %s, Error %q\n", msg.rel.Repo, msg.err)
+		}
 	}
 
 	log.Info("binman finished!")

--- a/pkg/files.go
+++ b/pkg/files.go
@@ -114,7 +114,7 @@ func handleTar(publishDir string, tarpath string) error {
 			log.Debugf("creating directory for %s", newDir)
 			err := os.MkdirAll(newDir, 0750)
 			if err != nil {
-				log.Warnf("Errore creating %s,%v", newDir, err)
+				log.Warnf("Error creating %s,%v", newDir, err)
 			}
 		}
 

--- a/pkg/files.go
+++ b/pkg/files.go
@@ -2,6 +2,7 @@ package binman
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -17,6 +18,65 @@ import (
 func isTar(filepath string) bool {
 	boolReturn, _ := regexp.MatchString(TarRegEx, filepath)
 	return boolReturn
+}
+
+func isZip(filepath string) bool {
+	boolReturn, _ := regexp.MatchString(ZipRegEx, filepath)
+	return boolReturn
+}
+
+func handleZip(publishDir string, zippath string) error {
+	archive, err := zip.OpenReader(zippath)
+	if err != nil {
+		log.Warnf("Unable to open %s", zippath)
+		return err
+	}
+	defer archive.Close()
+
+	for _, f := range archive.File {
+		dstPath := filepath.Join(publishDir, f.Name)
+
+		if !strings.HasPrefix(dstPath, filepath.Clean(publishDir)+string(os.PathSeparator)) {
+			log.Warnf("Extracted file would have had an invalid path, cannot continue")
+			return fmt.Errorf("Extracted file would have had an invalid path, cannot continue")
+		}
+
+		if f.FileInfo().IsDir() {
+			log.Debugf("creating directory for %s", dstPath)
+			err := os.MkdirAll(dstPath, 0750)
+			if err != nil {
+				log.Warnf("Error creating %s, %v", dstPath, err)
+				return fmt.Errorf("Error creating %s, %v", dstPath, err)
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dstPath), os.ModePerm); err != nil {
+			log.Warnf("Error creating %s, %v", filepath.Dir(dstPath), err)
+			return fmt.Errorf("Error creating %s, %v", filepath.Dir(dstPath), err)
+		}
+
+		dstFile, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			log.Warnf("Error creating %s, %v", dstPath, err)
+			return fmt.Errorf("Error creating %s, %v", dstPath, err)
+		}
+		defer dstFile.Close()
+
+		fileInArchive, err := f.Open()
+		if err != nil {
+			log.Warnf("Could not read file inside zip: %s, %v", f.Name, err)
+			return fmt.Errorf("Could not read file inside zip: %s, %v", f.Name, err)
+		}
+		defer fileInArchive.Close()
+
+		if _, err := io.Copy(dstFile, fileInArchive); err != nil {
+			log.Warnf("Could not copy file inside zip: %s, %v", f.Name, err)
+			return fmt.Errorf("Could not copy file inside zip: %s, %v", f.Name, err)
+		}
+	}
+
+	return nil
 }
 
 func handleTar(publishDir string, tarpath string) error {

--- a/pkg/gh/assets.go
+++ b/pkg/gh/assets.go
@@ -8,6 +8,7 @@ import (
 )
 
 const TarRegEx = `(\.tar$|\.tar\.gz$|\.tgz$)`
+const ZipRegEx = `(\.zip$)`
 
 // I should refactor this a bit to use a regex for Arch to interchange amd64 v x86_64
 // rel* vars should come in a interface
@@ -31,10 +32,11 @@ func FindAsset(relArch string, relOS string, assets []*github.ReleaseAsset) (str
 		// anything following by a "." and then any three characters
 		binCheck, _ := regexp.MatchString(`.*\....$`, an)
 		tarCheck, _ := regexp.MatchString(TarRegEx, an)
+		zipCheck, _ := regexp.MatchString(ZipRegEx, an)
 		exeCheck := strings.HasSuffix(an, ".exe")
 
 		// If the asset matches OS/ARCH and binCheck is false or tarCheck is true or exe check is true
-		if testOS && testArch && (!binCheck || tarCheck || exeCheck) {
+		if testOS && testArch && (!binCheck || tarCheck || zipCheck || exeCheck) {
 			return *asset.Name, *asset.BrowserDownloadURL
 		}
 	}

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -1,7 +1,6 @@
 package binman
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -67,7 +66,7 @@ func (r *BinmanRelease) setArtifactPath(ReleasePath string, tag string) {
 	if strings.HasSuffix(ReleasePath, "/") {
 		ReleasePath = strings.TrimSuffix(ReleasePath, "/")
 	}
-	r.PublishPath = fmt.Sprintf("%s/repos/%s/%s/%s", ReleasePath, r.Org, r.Project, tag)
+	r.PublishPath = filepath.Join(ReleasePath, "repos", r.Org, r.Project, tag)
 }
 
 // Helper method to set paths for a requested release object
@@ -87,26 +86,26 @@ func (r *BinmanRelease) setPublishPaths(ReleasePath string, assetName string) {
 	// else if it's a tar but we have specified the inside file use filename for source and destination
 	// else we want default
 	if r.ReleaseFileName != "" {
-		r.ArtifactPath = fmt.Sprintf("%s/%s", r.PublishPath, r.ReleaseFileName)
+		r.ArtifactPath = filepath.Join(r.PublishPath, r.ReleaseFileName)
 		log.Debugf("ReleaseFilenName set %s\n", r.ArtifactPath)
 	} else if r.ExtractFileName != "" {
-		r.ArtifactPath = fmt.Sprintf("%s/%s", r.PublishPath, r.ExtractFileName)
+		r.ArtifactPath = filepath.Join(r.PublishPath, r.ExtractFileName)
 		log.Debugf("Tar with Filename set %s\n", r.ArtifactPath)
 	} else if r.ExternalUrl != "" {
-		r.ArtifactPath = fmt.Sprintf("%s/%s", r.PublishPath, filepath.Base(r.ExternalUrl))
+		r.ArtifactPath = filepath.Join(r.PublishPath, filepath.Base(r.ExternalUrl))
 		log.Debugf("Tar with Filename set %s\n", r.ArtifactPath)
 	} else {
 		// If we find a tar in the assetName assume the name of the binary within the tar
 		// Else our default is a binary
 		if isTar(assetName) {
-			r.ArtifactPath = fmt.Sprintf("%s/%s", r.PublishPath, r.Project)
+			r.ArtifactPath = filepath.Join(r.PublishPath, r.Project)
 		} else {
-			r.ArtifactPath = fmt.Sprintf("%s/%s", r.PublishPath, assetName)
+			r.ArtifactPath = filepath.Join(r.PublishPath, assetName)
 		}
 		log.Debugf("Default Extraction %s\n", r.ArtifactPath)
 	}
 
-	r.LinkPath = fmt.Sprintf("%s/%s", ReleasePath, linkName)
+	r.LinkPath = filepath.Join(ReleasePath, linkName)
 	log.Debugf("Artifact Path %s Link Path %s\n", r.ArtifactPath, r.Project)
 
 }

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -15,6 +15,12 @@ import (
 const TarRegEx = `(\.tar$|\.tar\.gz$|\.tgz$)`
 const x86RegEx = `(amd64|x86_64)`
 
+// BinmanMsg contains return messages for binman's concurrent workers
+type BinmanMsg struct {
+	err error
+	rel BinmanRelease
+}
+
 // BinmanConfig contains Global Config Options
 type BinmanConfig struct {
 	ReleasePath string `yaml:"releasepath"`        //path to download/link releases from github

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -12,6 +12,7 @@ import (
 )
 
 const TarRegEx = `(\.tar$|\.tar\.gz$|\.tgz$)`
+const ZipRegEx = `(\.zip$)`
 const x86RegEx = `(amd64|x86_64)`
 
 // BinmanMsg contains return messages for binman's concurrent workers
@@ -87,17 +88,19 @@ func (r *BinmanRelease) setPublishPaths(ReleasePath string, assetName string) {
 	// else we want default
 	if r.ReleaseFileName != "" {
 		r.ArtifactPath = filepath.Join(r.PublishPath, r.ReleaseFileName)
-		log.Debugf("ReleaseFilenName set %s\n", r.ArtifactPath)
+		log.Debugf("ReleaseFileName set %s\n", r.ArtifactPath)
 	} else if r.ExtractFileName != "" {
 		r.ArtifactPath = filepath.Join(r.PublishPath, r.ExtractFileName)
-		log.Debugf("Tar with Filename set %s\n", r.ArtifactPath)
+		log.Debugf("Archive with Filename set %s\n", r.ArtifactPath)
 	} else if r.ExternalUrl != "" {
 		r.ArtifactPath = filepath.Join(r.PublishPath, filepath.Base(r.ExternalUrl))
-		log.Debugf("Tar with Filename set %s\n", r.ArtifactPath)
+		log.Debugf("Archive with ExternalURL set %s\n", r.ArtifactPath)
 	} else {
 		// If we find a tar in the assetName assume the name of the binary within the tar
 		// Else our default is a binary
 		if isTar(assetName) {
+			r.ArtifactPath = filepath.Join(r.PublishPath, r.Project)
+		} else if isZip(assetName) {
 			r.ArtifactPath = filepath.Join(r.PublishPath, r.Project)
 		} else {
 			r.ArtifactPath = filepath.Join(r.PublishPath, assetName)


### PR DESCRIPTION
@rjbrown57 

Made a few modifications to binMan to help with a few problems:
* When binman reads errors off of the channel, it can and usually does, receive results back on the channel that is out of the order that it reads configs from. Changed it to read directly from the channel for both the release repo name and the error. Plus added WaitGroup handling for better concurrency controls
* Added zip archive handling
* Changed sprintf filepath creations to filepath.Join
* Added a feature so that binman attempts to walk the unpacked archive directory in search of executables when all else fails, this helped me get around problems that I had with golangci-lint where the directory it unpacks to is a combination of the project name, and part of the version, and architecture