### PR TITLE
Binmanactions

### DIFF
--- a/pkg/actions.go
+++ b/pkg/actions.go
@@ -198,16 +198,24 @@ func (action *OsCommandAction) execute() error {
 
 	command := action.r.PostCommands[action.index].Command
 
-	log.Infof("Starting OS command %s for %s", command, action.r.Repo)
+	dataMap := action.r.getDataMap()
+
+	// Template any args
+	for i, arg := range action.r.PostCommands[action.index].Args {
+		action.r.PostCommands[action.index].Args[i] = formatString(arg, dataMap)
+	}
+
+	log.Infof("Starting OS command %s with args %s for %s ", command, action.r.PostCommands[action.index].Args, action.r.Repo)
 
 	out, err := exec.Command(command, action.r.PostCommands[action.index].Args...).Output()
 
 	if err != nil {
+		log.Warnf("error output for %s with args %s is %s", command, action.r.PostCommands[action.index].Args, out)
 		return err
 	}
 
-	log.Infof("%s complete on %s", command, action.r.Repo)
-	log.Infof("%s output %s", command, out)
+	log.Infof("%s with args %s complete on %s", command, action.r.PostCommands[action.index].Args, action.r.Repo)
+	log.Debugf("%s with args %s output: \n %s", command, action.r.PostCommands[action.index].Args, out)
 
 	return nil
 

--- a/pkg/actions.go
+++ b/pkg/actions.go
@@ -1,0 +1,221 @@
+package binman
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	log "github.com/rjbrown57/binman/pkg/logging"
+)
+
+type Action interface {
+	execute() error
+}
+
+type DownloadAction struct {
+	r *BinmanRelease
+}
+
+func (r *BinmanRelease) AddDownloadAction() Action {
+	return &DownloadAction{
+		r,
+	}
+}
+
+func (action *DownloadAction) execute() error {
+
+	log.Infof("Downloading %s", action.r.dlUrl)
+	resp, err := http.Get(action.r.dlUrl)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	out, err := os.Create(filepath.Clean(action.r.filepath))
+	if err != nil {
+		return err
+	}
+
+	defer out.Close()
+
+	_, err = io.Copy(io.MultiWriter(out), resp.Body)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Download %s complete", action.r.dlUrl)
+
+	return nil
+}
+
+// link action
+
+type LinkFileAction struct {
+	r *BinmanRelease
+}
+
+func (action *LinkFileAction) execute() error {
+	// If target exists, remove it
+	if _, err := os.Stat(action.r.LinkPath); err == nil {
+		log.Warnf("Updating %s to %s\n", action.r.ArtifactPath, action.r.LinkPath)
+		err := os.Remove(action.r.LinkPath)
+		if err != nil {
+			log.Warnf("Unable to remove %s,%v", action.r.LinkPath, err)
+		}
+	}
+
+	err := os.Symlink(action.r.ArtifactPath, action.r.LinkPath)
+	if err != nil {
+		log.Infof("Creating link %s -> %s\n", action.r.ArtifactPath, action.r.LinkPath)
+		return err
+	}
+
+	return nil
+}
+
+func (r *BinmanRelease) AddLinkFileAction() Action {
+	return &LinkFileAction{
+		r,
+	}
+}
+
+type MakeExecuteableAction struct {
+	r *BinmanRelease
+}
+
+func (action *MakeExecuteableAction) execute() error {
+	// make the file executable
+	err := os.Chmod(action.r.ArtifactPath, 0750)
+	if err != nil {
+		log.Warnf("Failed to set permissions on %s", action.r.PublishPath)
+		return err
+	}
+	return nil
+}
+
+func (r *BinmanRelease) AddMakeExecuteableAction() Action {
+	return &MakeExecuteableAction{
+		r,
+	}
+}
+
+// WriteReleaseNotes
+type WriteRelNotesAction struct {
+	r *BinmanRelease
+}
+
+func (action *WriteRelNotesAction) execute() error {
+	relNotes := action.r.GithubData.GetBody()
+	if relNotes != "" {
+		notePath := filepath.Join(action.r.PublishPath, "releaseNotes.txt")
+		log.Debugf("Notes written to %s", notePath)
+		return writeStringtoFile(notePath, relNotes)
+	}
+
+	return nil
+}
+
+func (r *BinmanRelease) AddWriteRelNotesAction() Action {
+	return &WriteRelNotesAction{
+		r,
+	}
+}
+
+// Extract
+type ExtractAction struct {
+	r *BinmanRelease
+}
+
+func (action *ExtractAction) execute() error {
+	switch findfType(action.r.filepath) {
+	case "tar":
+		log.Debugf("tar extract start")
+		err := handleTar(action.r.PublishPath, action.r.filepath)
+		if err != nil {
+			log.Warnf("Failed to extract tar file: %v", err)
+			return err
+		}
+	case "zip":
+		log.Debugf("zip extract start")
+		err := handleZip(action.r.PublishPath, action.r.filepath)
+		if err != nil {
+			log.Warnf("Failed to extract zip file: %v", err)
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+func (r *BinmanRelease) AddExtractAction() Action {
+	return &ExtractAction{
+		r,
+	}
+}
+
+// FindTarget
+type FindTargetAction struct {
+	r *BinmanRelease
+}
+
+func (action *FindTargetAction) execute() error {
+	// If the file still doesn't exist, attempt to find it in sub-directories
+	if _, err := os.Stat(action.r.ArtifactPath); errors.Is(err, os.ErrNotExist) {
+		log.Debugf("Wasn't able to find the artifact at %s, walking the directory to see if we can find it",
+			action.r.ArtifactPath)
+
+		// Walk the directory looking for the file. If found artifact path will be updated
+		action.r.findTarget()
+
+		if _, err := os.Stat(action.r.ArtifactPath); errors.Is(err, os.ErrNotExist) {
+			err := fmt.Errorf("unable to find a matching file for %s anywhere in the release archive", action.r.Repo)
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+func (r *BinmanRelease) AddFindTargetAction() Action {
+	return &FindTargetAction{
+		r,
+	}
+}
+
+type OsCommandAction struct {
+	r     *BinmanRelease
+	index int
+}
+
+func (action *OsCommandAction) execute() error {
+
+	command := action.r.PostCommands[action.index].Command
+
+	log.Infof("Starting OS command %s for %s", command, action.r.Repo)
+
+	out, err := exec.Command(command, action.r.PostCommands[action.index].Args...).Output()
+
+	if err != nil {
+		return err
+	}
+
+	log.Infof("%s complete on %s", command, action.r.Repo)
+	log.Infof("%s output %s", command, out)
+
+	return nil
+
+}
+
+func (r *BinmanRelease) AddOsCommandAction(index int) Action {
+	return &OsCommandAction{
+		r,
+		index,
+	}
+}

--- a/pkg/actions_test.go
+++ b/pkg/actions_test.go
@@ -154,9 +154,17 @@ func TestOsCommandAction(t *testing.T) {
 		},
 	}
 
+	var version string = "v0.0.0"
+
+	// Create a fake release
+	ghData := github.RepositoryRelease{
+		TagName: &version,
+	}
+
 	rel := BinmanRelease{
 		Repo:         "rjbrown57/binman",
 		PostCommands: coms,
+		GithubData:   &ghData,
 	}
 
 	rel.tasks = append(rel.tasks, rel.AddOsCommandAction(0))

--- a/pkg/actions_test.go
+++ b/pkg/actions_test.go
@@ -1,0 +1,169 @@
+package binman
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-github/v48/github"
+)
+
+func TestWriteRelNotesAction(t *testing.T) {
+
+	d, err := os.MkdirTemp(os.TempDir(), "binmwrn")
+	if err != nil {
+		t.Fatalf("unable to make temp dir %s", d)
+	}
+
+	defer os.RemoveAll(d)
+
+	// Create a dummy asset to detect in a subdir of the temp
+	var version string = "v0.0.0"
+	var bodyContent string = "test-test-test"
+
+	// Create a fake release
+	ghData := github.RepositoryRelease{
+		TagName: &version,
+		Body:    &bodyContent,
+	}
+
+	rel := BinmanRelease{
+		Repo:        "rjbrown57/binman",
+		PublishPath: d,
+		GithubData:  &ghData,
+	}
+
+	rel.tasks = append(rel.tasks, rel.AddWriteRelNotesAction())
+
+	if err = rel.tasks[0].execute(); err != nil {
+		t.Fatal("Unable to write release notes")
+	}
+
+	// Read the written release notes
+	notesBytes, err := os.ReadFile(filepath.Join(rel.PublishPath, "releaseNotes.txt"))
+	if err != nil {
+		t.Fatal("Unable to read written release notes")
+	}
+
+	if string(notesBytes) != bodyContent {
+		t.Fatalf("Want %s, got %s", bodyContent, notesBytes)
+	}
+
+}
+
+func TestLinkFileAction(t *testing.T) {
+
+	const content string = "stringcontent"
+	const linkname string = "test"
+
+	d, err := os.MkdirTemp(os.TempDir(), "binmwrn")
+	if err != nil {
+		t.Fatalf("unable to make temp dir %s", d)
+	}
+
+	filePath := filepath.Join(d, "testfile")
+	linkPath := filepath.Join(d, linkname)
+
+	defer os.RemoveAll(d)
+
+	rel := BinmanRelease{
+		Repo:         "rjbrown57/binman",
+		ArtifactPath: filePath,
+		LinkPath:     linkPath,
+	}
+
+	writeStringtoFile(rel.ArtifactPath, content)
+
+	// Add the link task twice, to confirm link is updated successfully
+	rel.tasks = append(rel.tasks, rel.AddLinkFileAction())
+	rel.tasks = append(rel.tasks, rel.AddLinkFileAction())
+
+	for _, task := range rel.tasks {
+		if err = task.execute(); err != nil {
+			t.Fatal("Unable to create release link")
+		}
+
+		if f, err := os.Stat(rel.LinkPath); err == nil {
+			if f.Name() != linkname {
+				t.Fatalf("Expected link name %s got %s", linkname, f.Name())
+			}
+
+			// Read the written release notes
+			contentBytes, err := os.ReadFile(rel.LinkPath)
+			if err != nil {
+				t.Fatal("Unable to read link contents")
+			}
+
+			if string(contentBytes) != content {
+				t.Fatalf("Want %s, got %s", content, contentBytes)
+			}
+		} else {
+			t.Fatal("Link was not created properly")
+		}
+	}
+
+}
+
+func TestMakeExecuteableAction(t *testing.T) {
+
+	const content string = "stringcontent"
+	testMode := os.FileMode(int(0750))
+
+	d, err := os.MkdirTemp(os.TempDir(), "binmwrn")
+	if err != nil {
+		t.Fatalf("unable to make temp dir %s", d)
+	}
+
+	filePath := filepath.Join(d, "testfile")
+
+	defer os.RemoveAll(d)
+
+	rel := BinmanRelease{
+		Repo:         "rjbrown57/binman",
+		ArtifactPath: filePath,
+	}
+
+	writeStringtoFile(rel.ArtifactPath, content)
+
+	rel.tasks = append(rel.tasks, rel.AddMakeExecuteableAction())
+
+	if err = rel.tasks[0].execute(); err != nil {
+		t.Fatal("Unable to create make file executable")
+	}
+
+	if f, err := os.Stat(rel.ArtifactPath); err == nil {
+		if f.Mode().Perm() != testMode.Perm() {
+			t.Fatalf("Expected %s got %s", "0750", f.Mode().String())
+		}
+	} else {
+		t.Fatal("Test file was not properly created")
+	}
+}
+
+// This test will only function properly on linux
+func TestOsCommandAction(t *testing.T) {
+
+	coms := []PostCommand{
+		{
+			Command: "echo",
+			Args:    []string{"hooray!"},
+		},
+		{
+			Command: "echo",
+			Args:    []string{"Hooray2"},
+		},
+	}
+
+	rel := BinmanRelease{
+		Repo:         "rjbrown57/binman",
+		PostCommands: coms,
+	}
+
+	rel.tasks = append(rel.tasks, rel.AddOsCommandAction(0))
+	rel.tasks = append(rel.tasks, rel.AddOsCommandAction(1))
+	for i, task := range rel.tasks {
+		if err := task.execute(); err != nil {
+			t.Fatalf("Unable to run post command %d", i)
+		}
+	}
+}

--- a/pkg/binman.go
+++ b/pkg/binman.go
@@ -83,8 +83,6 @@ func goSyncRepo(ghClient *github.Client, releasePath string, rel BinmanRelease, 
 	// Set paths based on asset we selected
 	rel.setArtifactPath(releasePath, rel.assetName)
 
-	rel.filepath = fmt.Sprintf("%s/%s", rel.PublishPath, rel.assetName)
-
 	// prepare directory path
 	err = os.MkdirAll(rel.PublishPath, 0750)
 	if err != nil {

--- a/pkg/binmanRelease.go
+++ b/pkg/binmanRelease.go
@@ -27,6 +27,9 @@ type BinmanRelease struct {
 	LinkPath        string    // Will be set by BinmanRelease.setPaths
 	Version         string    `yaml:"version,omitempty"` // Pull a specific version
 	GithubData      *github.RepositoryRelease
+	assetName       string // the target assetName
+	dlUrl           string // the final donwload url
+	filepath        string // the target filepath for download
 }
 
 // set project and org vars

--- a/pkg/binmanRelease.go
+++ b/pkg/binmanRelease.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v48/github"
+	log "github.com/rjbrown57/binman/pkg/logging"
 )
 
 // BinmanRelease contains info on specifc releases to hunt for

--- a/pkg/binmanRelease.go
+++ b/pkg/binmanRelease.go
@@ -1,6 +1,7 @@
 package binman
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,6 +124,8 @@ func (r *BinmanRelease) setArtifactPath(ReleasePath string, assetName string) {
 
 	r.LinkPath = filepath.Join(ReleasePath, linkName)
 	log.Debugf("Artifact Path %s Link Path %s\n", r.ArtifactPath, r.Project)
+
+	r.filepath = fmt.Sprintf("%s/%s", r.PublishPath, r.assetName)
 }
 
 func (r *BinmanRelease) writeReleaseNotes() error {

--- a/pkg/binmanRelease.go
+++ b/pkg/binmanRelease.go
@@ -12,26 +12,77 @@ import (
 
 // BinmanRelease contains info on specifc releases to hunt for
 type BinmanRelease struct {
-	Os              string    `yaml:"os,omitempty"`
-	Arch            string    `yaml:"arch,omitempty"`
-	CheckSum        bool      `yaml:"checkSum,omitempty"`
-	DownloadOnly    bool      `yaml:"downloadonly,omitempty"`
-	UpxConfig       UpxConfig `yaml:"upx,omitempty"`             // Allow shrinking with Upx
-	ExternalUrl     string    `yaml:"url,omitempty"`             // User provided external url to use with versions grabbed from GH. Note you must also set ReleaseFileName
-	ExtractFileName string    `yaml:"extractfilename,omitempty"` // The file within the release you want
-	ReleaseFileName string    `yaml:"releasefilename,omitempty"` // Specifc Release filename to look for. This is useful if a project publishes a binary and not a tarball.
-	Repo            string    `yaml:"repo"`                      // The specific repo name in github. e.g achore/syft
-	Org             string    // Will be provided by constuctor
-	Project         string    // Will be provided by constuctor
-	PublishPath     string    // Path Release will be set up at
-	ArtifactPath    string    // Will be set by BinmanRelease.setPaths. This is the source path for the link aka the executable binary
-	LinkName        string    `yaml:"linkname,omitempty"` // Set what the final link will be. Defaults to project name.
-	LinkPath        string    // Will be set by BinmanRelease.setPaths
-	Version         string    `yaml:"version,omitempty"` // Pull a specific version
+	Os              string        `yaml:"os,omitempty"`
+	Arch            string        `yaml:"arch,omitempty"`
+	CheckSum        bool          `yaml:"checkSum,omitempty"`
+	DownloadOnly    bool          `yaml:"downloadonly,omitempty"`
+	UpxConfig       UpxConfig     `yaml:"upx,omitempty"`             // Allow shrinking with Upx
+	ExternalUrl     string        `yaml:"url,omitempty"`             // User provided external url to use with versions grabbed from GH. Note you must also set ReleaseFileName
+	ExtractFileName string        `yaml:"extractfilename,omitempty"` // The file within the release you want
+	ReleaseFileName string        `yaml:"releasefilename,omitempty"` // Specifc Release filename to look for. This is useful if a project publishes a binary and not a tarball.
+	Repo            string        `yaml:"repo"`                      // The specific repo name in github. e.g achore/syft
+	Org             string        // Will be provided by constuctor
+	Project         string        // Will be provided by constuctor
+	PublishPath     string        // Path Release will be set up at
+	ArtifactPath    string        // Will be set by BinmanRelease.setPaths. This is the source path for the link aka the executable binary
+	LinkName        string        `yaml:"linkname,omitempty"` // Set what the final link will be. Defaults to project name.
+	LinkPath        string        // Will be set by BinmanRelease.setPaths
+	Version         string        `yaml:"version,omitempty"` // Pull a specific version
+	PostCommands    []PostCommand `yaml:"postcommands,omitempty"`
 	GithubData      *github.RepositoryRelease
-	assetName       string // the target assetName
-	dlUrl           string // the final donwload url
-	filepath        string // the target filepath for download
+	assetName       string   // the target assetName
+	dlUrl           string   // the final donwload url
+	filepath        string   // the target filepath for download
+	tasks           []Action // the actions we will perform for this release
+}
+
+type PostCommand struct {
+	Command string   `yaml:"command"`
+	Args    []string `yaml:"args,omitempty"`
+}
+
+// getPostStepTasks will arrange all final work after we have selected an asset
+func (r *BinmanRelease) getPostStepTasks() {
+
+	r.tasks = append(r.tasks, r.AddDownloadAction())
+
+	if r.DownloadOnly {
+		return
+	}
+
+	switch findfType(r.filepath) {
+	case "tar":
+		r.tasks = append(r.tasks, r.AddExtractAction())
+	case "zip":
+		r.tasks = append(r.tasks, r.AddExtractAction())
+	case "default":
+	}
+
+	r.tasks = append(r.tasks, r.AddFindTargetAction(),
+		r.AddMakeExecuteableAction(),
+		r.AddLinkFileAction(),
+		r.AddWriteRelNotesAction())
+
+	// Upx needs to be prepended to PostCommands if user has requested
+	if r.UpxConfig.Enabled == "true" {
+
+		// Merge any user args with upx
+		args := []string{r.ArtifactPath}
+		args = append(args, r.UpxConfig.Args...)
+
+		UpxCommand := PostCommand{
+			Command: "upx",
+			Args:    args,
+		}
+
+		r.PostCommands = append([]PostCommand{UpxCommand}, r.PostCommands...)
+	}
+
+	// Add post commands defined by user
+	for index := range r.PostCommands {
+		r.tasks = append(r.tasks, r.AddOsCommandAction(index))
+	}
+
 }
 
 // set project and org vars
@@ -126,15 +177,4 @@ func (r *BinmanRelease) setArtifactPath(ReleasePath string, assetName string) {
 	log.Debugf("Artifact Path %s Link Path %s\n", r.ArtifactPath, r.Project)
 
 	r.filepath = fmt.Sprintf("%s/%s", r.PublishPath, r.assetName)
-}
-
-func (r *BinmanRelease) writeReleaseNotes() error {
-	relNotes := r.GithubData.GetBody()
-	if relNotes != "" {
-		notePath := filepath.Join(r.PublishPath, "releaseNotes.txt")
-		log.Debugf("Notes written to %s", notePath)
-		return writeStringtoFile(notePath, relNotes)
-	}
-
-	return nil
 }

--- a/pkg/binmanRelease_test.go
+++ b/pkg/binmanRelease_test.go
@@ -3,7 +3,6 @@ package binman
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/google/go-github/v48/github"
@@ -170,47 +169,6 @@ func TestSetArtifactPath(t *testing.T) {
 			t.Fatalf("Artifact Path expected %s, got %s", test.exectedArtifactPath, test.rel.ArtifactPath)
 		}
 	}
-}
-
-func TestWriteReleaseNotes(t *testing.T) {
-
-	d, err := os.MkdirTemp(os.TempDir(), "binmwrn")
-	if err != nil {
-		t.Fatalf("unable to make temp dir %s", d)
-	}
-
-	defer os.RemoveAll(d)
-
-	// Create a dummy asset to detect in a subdir of the temp
-	var version string = "v0.0.0"
-	var bodyContent string = "test-test-test"
-
-	// Create a fake release
-	ghData := github.RepositoryRelease{
-		TagName: &version,
-		Body:    &bodyContent,
-	}
-
-	rel := BinmanRelease{
-		Repo:        "rjbrown57/binman",
-		PublishPath: d,
-		GithubData:  &ghData,
-	}
-
-	if err = rel.writeReleaseNotes(); err != nil {
-		t.Fatal("Unable to write release notes")
-	}
-
-	// Read the written release notes
-	notesBytes, err := os.ReadFile(filepath.Join(rel.PublishPath, "releaseNotes.txt"))
-	if err != nil {
-		t.Fatal("Unable to read written release notes")
-	}
-
-	if string(notesBytes) != bodyContent {
-		t.Fatalf("Want %s, got %s", bodyContent, notesBytes)
-	}
-
 }
 
 func TestGetDataMap(t *testing.T) {

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -3,6 +3,8 @@ package binman
 import (
 	"fmt"
 	"os"
+
+	log "github.com/rjbrown57/binman/pkg/logging"
 )
 
 // if user does not provide a -c this will be populated at ~/.config/binman/config
@@ -101,7 +103,7 @@ func mustEnsureDefaultPaths() string {
 
 	binmanConfigPath, err := os.UserConfigDir()
 	if err != nil {
-		log.Fatal("Unable to find config dir")
+		log.Fatalf("Unable to find config dir")
 	}
 
 	binmanConfigPath = binmanConfigPath + "/binman"

--- a/pkg/files.go
+++ b/pkg/files.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -155,56 +154,9 @@ func GunZipFile(gzipFile io.Reader) *gzip.Reader {
 	return uncompressedStream
 }
 
-// Create the link to new release
-func createReleaseLink(source string, target string) error {
-
-	// If target exists, remove it
-	if _, err := os.Stat(target); err == nil {
-		log.Warnf("Updating %s to %s\n", source, target)
-		err := os.Remove(target)
-		if err != nil {
-			log.Warnf("Unable to remove %s,%v", target, err)
-		}
-	}
-
-	err := os.Symlink(source, target)
-	if err != nil {
-		log.Infof("Creating link %s -> %s\n", source, target)
-		return err
-	}
-
-	return nil
-}
 
 func writeStringtoFile(path string, thestring string) error {
 	return os.WriteFile(path, []byte(thestring), 0600)
-}
-
-func downloadFile(path string, url string) error {
-
-	log.Infof("Downloading %s", url)
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
-	}
-
-	defer resp.Body.Close()
-
-	out, err := os.Create(filepath.Clean(path))
-	if err != nil {
-		return err
-	}
-
-	defer out.Close()
-
-	_, err = io.Copy(io.MultiWriter(out), resp.Body)
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Download %s complete", url)
-
-	return nil
 }
 
 // mustUnmarshalYaml will Unmarshall from config to GHBMConfig

--- a/pkg/files.go
+++ b/pkg/files.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strings"
 
+	log "github.com/rjbrown57/binman/pkg/logging"
 	"gopkg.in/yaml.v2"
 )
 
@@ -148,7 +149,7 @@ func handleTar(publishDir string, tarpath string) error {
 func GunZipFile(gzipFile io.Reader) *gzip.Reader {
 	uncompressedStream, err := gzip.NewReader(gzipFile)
 	if err != nil {
-		log.Fatal("ExtractTarGz: NewReader failed")
+		log.Fatalf("ExtractTarGz: NewReader failed")
 	}
 
 	return uncompressedStream

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,44 @@
+package logging
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+var log = logrus.New()
+
+func ConfigureLog(jsonLog bool, debug bool) {
+	// logging
+	if jsonLog {
+		log.Formatter = &logrus.JSONFormatter{}
+	}
+
+	log.Out = os.Stdout
+
+	if debug {
+		log.Level = logrus.DebugLevel
+	} else {
+		log.Level = logrus.InfoLevel
+	}
+}
+
+func Infof(format string, v ...interface{}) {
+	log.Infof(format, v...)
+}
+
+func Warnf(format string, v ...interface{}) {
+	log.Warnf(format, v...)
+}
+
+func Debugf(format string, v ...interface{}) {
+	log.Debugf(format, v...)
+}
+
+func Errorf(format string, v ...interface{}) {
+	log.Errorf(format, v...)
+}
+
+func Fatalf(format string, v ...interface{}) {
+	log.Fatalf(format, v...)
+}

--- a/pkg/templating.go
+++ b/pkg/templating.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+	log "github.com/rjbrown57/binman/pkg/logging"
 )
 
 // KnownUrlMap contains "projectname/repo" = "downloadurl" for common release assets not hosted on github

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"runtime"
 	"sync"
+
+	log "github.com/rjbrown57/binman/pkg/logging"
 )
 
 const TarRegEx = `(\.tar$|\.tar\.gz$|\.tgz$)`
@@ -135,7 +137,7 @@ func (config *GHBMConfig) setDefaults() {
 	}
 
 	if config.Config.TokenVar == "" {
-		log.Warn("config.tokenvar is not set. Using anonymous authentication. Please be aware you can quickly be rate limited by github. Instructions here https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token")
+		log.Warnf("config.tokenvar is not set. Using anonymous authentication. Please be aware you can quickly be rate limited by github. Instructions here https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token")
 		config.Config.TokenVar = "none"
 	}
 

--- a/pkg/types_test.go
+++ b/pkg/types_test.go
@@ -154,7 +154,7 @@ func TestPopulateReleases(t *testing.T) {
 		t.Fatalf("unable to make temp dir %s", d)
 	}
 
-	//defer os.RemoveAll(d)
+	defer os.RemoveAll(d)
 
 	configPath := fmt.Sprintf("%s/config", d)
 


### PR DESCRIPTION
* Refactors to ease future development
  * Move logging to it's own package
  * Move more vars to BinmanRelease type
* Update to use "command" pattern for all post work.  This greatly simplifies the gosyncrepo function and should make testing and extending binman easier. This pattern will be extended to the "pre-sync" tasks eventually to.

this includes the ability to set "commands" per release to be executed after download. A simple example


```
releases:
  - repo: rjbrown57/binman
    postCommands:
      - command: "cp"
        args: ["/tmp/repos/rjbrown57/binman/v0.1.4/binman_linux_amd64","/usr/local/bin/"]
```

A more fun example
```
releases:
  - repo: rjbrown57/binman
    postCommands:
    - command: docker
      args: ["build","-t","{{ .project }}","--build-arg","VERSION={{ .version }}","--build-arg","FILENAME={{ .filename }}","/home/lookfar/binMan/repos/{{ .org }}/{{ .project }}/"]
  - repo: rjbrown57/binextractor
      releasefilename: binextractor_0.0.1-alpha_linux_amd64
      downloadonly: true
      postCommands:
      - command: cp
        args: ["{{ .artifactpath }}","/tmp/binextractor"]
```