### PR TITLE
Walk update

### DIFF
--- a/pkg/binman.go
+++ b/pkg/binman.go
@@ -126,13 +126,15 @@ func Main(work map[string]string, debug bool, jsonLog bool) {
 			continue
 		}
 
-		log.Debugf("Repo %s, Error %q, cleaning up %s\n", msg.rel.Repo, msg.err, msg.rel.publishPath)
+		log.Warnf("Repo %s, Error %q, cleaning up %s\n", msg.rel.Repo, msg.err, msg.rel.publishPath)
 		if msg.rel.cleanupOnFailure {
 			err := os.RemoveAll(msg.rel.publishPath)
 			if err != nil {
 				log.Warnf("Unable to clean up %s - %s", msg.rel.publishPath, err)
 			}
-			log.Debugf("cleaned %s\n", msg.rel.publishPath)
+			log.Warnf("cleaned %s\n", msg.rel.publishPath)
+			log.Debugf("Final release data  %+v\n", msg.rel)
+
 		}
 	}
 

--- a/pkg/binmanRelease_test.go
+++ b/pkg/binmanRelease_test.go
@@ -33,7 +33,7 @@ func TestFindTarget(t *testing.T) {
 
 	// Create test file dir within temp dir
 	td := fmt.Sprintf("%s/%s", d, "test")
-	os.Mkdir(td, 0644)
+	os.Mkdir(td, 0744)
 	if err != nil {
 		t.Fatalf("unable to make temp dir %s", td)
 	}

--- a/pkg/files.go
+++ b/pkg/files.go
@@ -219,10 +219,20 @@ func GunZipFile(gzipFile io.Reader) *gzip.Reader {
 
 func MakeExecuteable(path string) error {
 	// make the file executable
-	err := os.Chmod(path, 0750)
+	f, err := os.Stat(path)
 	if err != nil {
-		log.Warnf("Failed to set permissions on %s", path)
+		log.Warnf("Failed to open %s", path)
 		return err
+	}
+
+	// Set perms if required
+	if mode := f.Mode(); mode&os.ModePerm != 0755 {
+		log.Debugf("Settings perms to 755 for %s", path)
+		err = os.Chmod(path, 0755)
+		if err != nil {
+			log.Warnf("Failed to set permissions on %s", path)
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/files.go
+++ b/pkg/files.go
@@ -163,6 +163,12 @@ func handleTar(publishDir string, tarpath string) error {
 			return err
 		}
 
+		os.Chmod(filepath.Clean(publishPath), file.FileInfo().Mode())
+		if err != nil {
+			log.Warnf("Unable to set perms on file %s", publishPath)
+			return err
+		}
+
 	}
 }
 

--- a/pkg/files_test.go
+++ b/pkg/files_test.go
@@ -168,7 +168,7 @@ func TestMakeExecutable(t *testing.T) {
 		t.Fatalf("Unable to read %s", err)
 	}
 
-	if mode := f.Mode(); mode&os.ModePerm == 750 {
-		t.Fatalf("Permissions for %s are %o not 0750", writePath, mode)
+	if mode := f.Mode(); mode&os.ModePerm == 755 {
+		t.Fatalf("Permissions for %s are %o not 0755", writePath, mode)
 	}
 }

--- a/pkg/gh/assets.go
+++ b/pkg/gh/assets.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v48/github"
+	log "github.com/rjbrown57/binman/pkg/logging"
 )
 
 const TarRegEx = `(\.tar$|\.tar\.gz$|\.tgz$)`
@@ -17,6 +18,7 @@ const x86RegEx = `(amd64|x86_64)`
 func GetAssetbyName(relFileName string, assets []*github.ReleaseAsset) (string, string) {
 	for _, asset := range assets {
 		if *asset.Name == relFileName {
+			log.Debugf("Selected asset == %+v\n", *asset.Name)
 			return *asset.Name, *asset.BrowserDownloadURL
 		}
 	}
@@ -43,12 +45,14 @@ func FindAsset(relArch string, relOS string, assets []*github.ReleaseAsset) (str
 
 		// This asset matches our OS/Arch
 		if osRx.MatchString(an) && archRx.MatchString(an) {
+			log.Debugf("Evaluating asset %s\n", *asset.Name)
+
 			// If asset matches one of our supported styles return name+download url
 			// Current styles are tar,zip,exe,linux binary
 			switch {
 			case exeRx.MatchString(an), !strings.Contains(an, "."), tarRx.MatchString(an), zipRx.MatchString(an):
+				log.Debugf("Selected asset == %+v\n", asset)
 				return *asset.Name, *asset.BrowserDownloadURL
-
 			}
 
 		}

--- a/pkg/gh/ghClient.go
+++ b/pkg/gh/ghClient.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/google/go-github/v48/github"
+	log "github.com/rjbrown57/binman/pkg/logging"
 	"golang.org/x/oauth2"
 )
 
@@ -13,9 +14,11 @@ func GetGHCLient(tokenvar string) *github.Client {
 
 	// No auth client if user does not supply envvar
 	if tokenvar == "none" {
+		log.Debugf("Returning github client without auth")
 		return github.NewClient(nil)
 	}
 
+	log.Debugf("Returning github client using %s for auth", tokenvar)
 	ghtoken := os.Getenv(tokenvar)
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(

--- a/pkg/postactions_test.go
+++ b/pkg/postactions_test.go
@@ -111,7 +111,7 @@ func TestMakeExecuteableAction(t *testing.T) {
 	var actions []Action
 
 	const content string = "stringcontent"
-	testMode := os.FileMode(int(0750))
+	testMode := os.FileMode(int(0755))
 
 	d, err := os.MkdirTemp(os.TempDir(), "binmwrn")
 	if err != nil {
@@ -137,7 +137,7 @@ func TestMakeExecuteableAction(t *testing.T) {
 
 	if f, err := os.Stat(rel.artifactPath); err == nil {
 		if f.Mode().Perm() != testMode.Perm() {
-			t.Fatalf("Expected %s got %s", "0750", f.Mode().String())
+			t.Fatalf("Expected %o got %o", testMode, f.Mode())
 		}
 	} else {
 		t.Fatal("Test file was not properly created")

--- a/pkg/preactions.go
+++ b/pkg/preactions.go
@@ -67,12 +67,11 @@ func (action *SetUrlAction) execute() error {
 		rFilename := formatString(action.r.ReleaseFileName, action.r.getDataMap())
 		log.Debugf("Get asset by name %s", rFilename)
 		action.r.assetName, action.r.dlUrl = gh.GetAssetbyName(rFilename, action.r.githubData.Assets)
-		return nil
+	} else {
+		// Attempt to find the asset via arch/os
+		log.Debugf("Attempt to find asset %s", action.r.ReleaseFileName)
+		action.r.assetName, action.r.dlUrl = gh.FindAsset(action.r.Arch, action.r.Os, action.r.githubData.Assets)
 	}
-
-	// Attempt to find the asset via arch/os
-	log.Debugf("Attempt to find asset %s", action.r.ReleaseFileName)
-	action.r.assetName, action.r.dlUrl = gh.FindAsset(action.r.Arch, action.r.Os, action.r.githubData.Assets)
 
 	// If at this point dlUrl is not set we have an issue
 	if action.r.dlUrl == "" {


### PR DESCRIPTION
* Update findTarget to looking for "exact" matches and "possible" matches to limit the need to use extractfilename option. If an exact match is found we terminate early, if the the user specifies a file to extract we will only allow that file. If these are not set then we look for any non tar/zip/dir with 755 permissions. If there are multiple matches the last possible match will be used.
* When a release fails to complete all actions we will now clean up anything created
* Add logging to pkg/gh functions. This can be useful if you are not finding an asset to get