### PR TITLE
Assetrefactor

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -30,8 +30,10 @@ var configAddCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Add a repo to your binman config",
 	Long:  `Add a repo to your binman config`,
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		binmanconfig.Add(config, repo)
+		validateRepo(args[0])
+		binmanconfig.Add(config, args[0])
 	},
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,10 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-	"strings"
-
 	binman "github.com/rjbrown57/binman/pkg"
 	"github.com/spf13/cobra"
 )
@@ -17,14 +13,9 @@ var getCmd = &cobra.Command{
 	Example: "binman get rjbrown57/binman",
 	Long:    `get a single repo with binman. Useful with CI/docker`,
 	Run: func(cmd *cobra.Command, args []string) {
+		validateRepo(args[0])
 		m := make(map[string]string)
 		m["configFile"] = config
-
-		if !strings.Contains(args[0], "/") {
-			fmt.Printf("%s must be in the format org/repo", args[0])
-			os.Exit(1)
-		}
-
 		m["repo"] = args[0]
 		m["version"] = version
 		m["path"] = path

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	binman "github.com/rjbrown57/binman/pkg"
 	"github.com/spf13/cobra"
@@ -46,14 +48,17 @@ func Execute() {
 	}
 }
 
+func validateRepo(repo string) {
+	if !strings.Contains(repo, "/") {
+		fmt.Printf("Error: %s must be in the format org/repo\n", repo)
+		os.Exit(1)
+	}
+}
+
 func addSubcommands() {
 	// add edit/get to config
 	configCmd.AddCommand(configEditCmd)
 	configCmd.AddCommand(configGetCmd)
-
-	// Setup repo flag and add to root
-	configAddCmd.Flags().StringVarP(&repo, "repo", "r", "", "Supply repo to add to config in format org/repo")
-	configAddCmd.MarkFlagRequired("repo")
 	configCmd.AddCommand(configAddCmd)
 
 	// add config to root

--- a/pkg/binman.go
+++ b/pkg/binman.go
@@ -62,13 +62,18 @@ func BinmanGetReleasePrep(work map[string]string) []BinmanRelease {
 	}
 
 	rel := BinmanRelease{
-		Repo:         work["repo"],
-		Os:           runtime.GOOS,
-		Arch:         runtime.GOARCH,
-		publishPath:  work["path"],
-		QueryType:    "release",
-		DownloadOnly: true,
-		Version:      work["version"],
+		Repo:             work["repo"],
+		Os:               runtime.GOOS,
+		Arch:             runtime.GOARCH,
+		publishPath:      work["path"],
+		QueryType:        "release",
+		DownloadOnly:     true,
+		cleanupOnFailure: false,
+		Version:          work["version"],
+	}
+
+	if rel.Version != "" {
+		rel.QueryType = "releasebytag"
 	}
 
 	rel.getOR()

--- a/pkg/binman.go
+++ b/pkg/binman.go
@@ -132,7 +132,7 @@ func Main(args map[string]string, debug bool, jsonLog bool, launchCommand string
 			continue
 		}
 
-		log.Warnf("Repo %s, Error %q, cleaning up %s\n", msg.rel.Repo, msg.err, msg.rel.publishPath)
+		log.Warnf("Repo %s, Error %q\n", msg.rel.Repo, msg.err)
 		if msg.rel.cleanupOnFailure {
 			err := os.RemoveAll(msg.rel.publishPath)
 			if err != nil {
@@ -140,7 +140,6 @@ func Main(args map[string]string, debug bool, jsonLog bool, launchCommand string
 			}
 			log.Warnf("cleaned %s\n", msg.rel.publishPath)
 			log.Debugf("Final release data  %+v\n", msg.rel)
-
 		}
 	}
 

--- a/pkg/binman_test.go
+++ b/pkg/binman_test.go
@@ -8,31 +8,55 @@ import (
 )
 
 func TestBinmanGetReleasePrep(t *testing.T) {
+
+	// QueryType releasebytag
 	m := make(map[string]string)
 	m["configFile"] = "config"
 	m["repo"] = "org/repo"
 	m["version"] = "v0.0.0"
 	releasePath, err := os.Getwd()
-	m["path"] = releasePath
 	if err != nil {
-		t.Fatal("Unable to get current working director")
+		t.Fatal("Unable to get current working directory")
+	}
+	m["path"] = releasePath
+
+	// a second map that will be QueryType release
+	m2 := make(map[string]string)
+	m2["configFile"] = "config"
+	m2["repo"] = "org/repo"
+	m2["path"] = releasePath
+	m2["version"] = ""
+
+	var tests = []struct {
+		Expected BinmanRelease
+		Got      []BinmanRelease
+		dataMap  map[string]string
+	}{
+		{Expected: BinmanRelease{Repo: m["repo"],
+			project:      "repo",
+			org:          "org",
+			Os:           runtime.GOOS,
+			Arch:         runtime.GOARCH,
+			publishPath:  releasePath,
+			DownloadOnly: true,
+			Version:      m["version"],
+			QueryType:    "releasebytag"},
+			dataMap: m},
+		{Expected: BinmanRelease{Repo: m["repo"],
+			project:      "repo",
+			org:          "org",
+			Os:           runtime.GOOS,
+			Arch:         runtime.GOARCH,
+			publishPath:  releasePath,
+			DownloadOnly: true,
+			QueryType:    "release"},
+			dataMap: m2},
 	}
 
-	expectedRel := BinmanRelease{
-		Repo:         m["repo"],
-		project:      "repo",
-		org:          "org",
-		Os:           runtime.GOOS,
-		Arch:         runtime.GOARCH,
-		publishPath:  releasePath,
-		QueryType:    "release",
-		DownloadOnly: true,
-		Version:      m["version"],
-	}
-
-	gotRel := BinmanGetReleasePrep(m)
-
-	if fmt.Sprintf("%v", gotRel[0]) != fmt.Sprintf("%v", expectedRel) {
-		t.Fatalf("%v != %v", gotRel[0], expectedRel)
+	for _, test := range tests {
+		test.Got = BinmanGetReleasePrep(test.dataMap)
+		if fmt.Sprintf("%v", test.Got[0]) != fmt.Sprintf("%v", test.Expected) {
+			t.Fatalf("got - %v\n expected - %v", test.Got[0], test.Expected)
+		}
 	}
 }

--- a/pkg/getactions.go
+++ b/pkg/getactions.go
@@ -27,7 +27,9 @@ func (action *GetGHLatestReleaseAction) execute() error {
 
 	log.Debugf("Querying github api for latest release of %s", action.r.Repo)
 	// https://docs.github.com/en/rest/releases/releases#get-the-latest-release
-	action.r.githubData, _, err = action.ghClient.Repositories.GetLatestRelease(ctx, action.r.org, action.r.project)
+	if action.r.githubData, _, err = action.ghClient.Repositories.GetLatestRelease(ctx, action.r.org, action.r.project); err == nil {
+		action.r.Version = action.r.githubData.GetTagName()
+	}
 
 	return err
 }

--- a/pkg/gh/assets_test.go
+++ b/pkg/gh/assets_test.go
@@ -12,12 +12,17 @@ func createTestData(passCase string) []*github.ReleaseAsset {
 	var bogusString = "what.ami"
 	var wrongOs = "file_other_os.zip"
 	var wrongEnding = "file_linux_amd64.wrongending"
+	var possibleMatch = "file_v0.0.0_linux_amd64"
+	var possibleMatch2 = "file_0.0.0_linux_amd64"
 
 	assets := []*github.ReleaseAsset{
 		{Name: &bogusString, BrowserDownloadURL: &bogusString},
 		{Name: &wrongOs, BrowserDownloadURL: &wrongOs},
 		{Name: &wrongEnding, BrowserDownloadURL: &wrongEnding},
 		{Name: &passCase, BrowserDownloadURL: &passCase},
+		{Name: &passCase, BrowserDownloadURL: &passCase},
+		{Name: &passCase, BrowserDownloadURL: &possibleMatch},
+		{Name: &passCase, BrowserDownloadURL: &possibleMatch2},
 	}
 
 	return assets
@@ -26,25 +31,26 @@ func createTestData(passCase string) []*github.ReleaseAsset {
 // TestFindAsset will test each passing asset type
 func TestFindAsset(t *testing.T) {
 
-	var passCases = []string{"file_linux_amd64.zip", // a zip
+	var passCases = []string{
+		"file_linux_amd64.zip",    // a zip
 		"file_linux_amd64.tar",    // tar form 1
 		"file_linux_amd64.tar.gz", // tar form 2
 		"file_linux_amd64.tgz",    // tar form 3
 		"file_linux_amd64.exe",    // an exe
 		"file_linux_amd64",        // a binary
+		"file_v0.0.0_linux_amd64", // possible match 1
+		"file_0.0.0_linux_amd64",  // possible match 2
 	}
 	for _, testString := range passCases {
-		name, _ := FindAsset("linux", "amd64", createTestData(testString))
+		name, _ := FindAsset("linux", "amd64", "v0.0.0", "file", createTestData(testString))
 		if name != testString {
 			t.Fatalf("FindAsset test failed. %s does not match %s", name, testString)
 		}
 	}
-}
 
-// TestFindAssetNil should not find a match
-func TestFindAssetNil(t *testing.T) {
+	// find nothing
 	var nilString = "file_linux_amd64.nil"
-	name, _ := FindAsset("linux", "amd64", createTestData(nilString))
+	name, _ := FindAsset("linux", "amd64", "v0.0.0", "file", createTestData(nilString))
 
 	if name != "" {
 		t.Fatalf("FindAsset nil test failed. Name should be empty!")

--- a/pkg/preactions.go
+++ b/pkg/preactions.go
@@ -70,7 +70,7 @@ func (action *SetUrlAction) execute() error {
 	} else {
 		// Attempt to find the asset via arch/os
 		log.Debugf("Attempt to find asset %s", action.r.ReleaseFileName)
-		action.r.assetName, action.r.dlUrl = gh.FindAsset(action.r.Arch, action.r.Os, action.r.githubData.Assets)
+		action.r.assetName, action.r.dlUrl = gh.FindAsset(action.r.Arch, action.r.Os, action.r.Version, action.r.project, action.r.githubData.Assets)
 	}
 
 	// If at this point dlUrl is not set we have an issue


### PR DESCRIPTION
* Refactor asset selection to lessen need for use of releasefilename. Now uses exact match and possible match style used by findTarget.
* Use args instead of flags for config add