### PR TITLE
fix(actions): don't link on error

### DIFF
--- a/pkg/actions.go
+++ b/pkg/actions.go
@@ -95,10 +95,15 @@ func (r *BinmanRelease) setPostActions() []Action {
 
 		actions = append(actions, r.AddFindTargetAction(),
 			r.AddMakeExecuteableAction(),
-			r.AddLinkFileAction(),
 			r.AddWriteRelNotesAction())
 	}
 
 	return actions
 
+}
+
+// setFinalActions assuming that all previous post and OS related actions have been successful perform final actions
+// (like linking the binary to the new release)
+func (r *BinmanRelease) setFinalActions() []Action {
+	return []Action{r.AddLinkFileAction()}
 }

--- a/pkg/actions_test.go
+++ b/pkg/actions_test.go
@@ -115,27 +115,27 @@ func TestSetPostActions(t *testing.T) {
 		{
 			"basic",
 			relBase.setPostActions(),
-			[]string{"*binman.DownloadAction", "*binman.FindTargetAction", "*binman.MakeExecuteableAction", "*binman.LinkFileAction", "*binman.WriteRelNotesAction"},
+			[]string{"*binman.DownloadAction", "*binman.FindTargetAction", "*binman.MakeExecuteableAction", "*binman.WriteRelNotesAction"},
 		},
 		{
 			"tar",
 			relWithTar.setPostActions(),
-			[]string{"*binman.DownloadAction", "*binman.ExtractAction", "*binman.FindTargetAction", "*binman.MakeExecuteableAction", "*binman.LinkFileAction", "*binman.WriteRelNotesAction"},
+			[]string{"*binman.DownloadAction", "*binman.ExtractAction", "*binman.FindTargetAction", "*binman.MakeExecuteableAction", "*binman.WriteRelNotesAction"},
 		},
 		{
 			"zip",
 			relWithZip.setPostActions(),
-			[]string{"*binman.DownloadAction", "*binman.ExtractAction", "*binman.FindTargetAction", "*binman.MakeExecuteableAction", "*binman.LinkFileAction", "*binman.WriteRelNotesAction"},
+			[]string{"*binman.DownloadAction", "*binman.ExtractAction", "*binman.FindTargetAction", "*binman.MakeExecuteableAction", "*binman.WriteRelNotesAction"},
 		},
 		{
 			"basicupx",
 			relWithUpx.setPostActions(),
-			[]string{"*binman.DownloadAction", "*binman.FindTargetAction", "*binman.MakeExecuteableAction", "*binman.LinkFileAction", "*binman.WriteRelNotesAction", "*binman.OsCommandAction"},
+			[]string{"*binman.DownloadAction", "*binman.FindTargetAction", "*binman.MakeExecuteableAction", "*binman.WriteRelNotesAction", "*binman.OsCommandAction"},
 		},
 		{
 			"basicmultiplepostcommands",
 			relWithUpxandPostCommands.setPostActions(),
-			[]string{"*binman.DownloadAction", "*binman.FindTargetAction", "*binman.MakeExecuteableAction", "*binman.LinkFileAction", "*binman.WriteRelNotesAction", "*binman.OsCommandAction", "*binman.OsCommandAction", "*binman.OsCommandAction"},
+			[]string{"*binman.DownloadAction", "*binman.FindTargetAction", "*binman.MakeExecuteableAction", "*binman.WriteRelNotesAction", "*binman.OsCommandAction", "*binman.OsCommandAction", "*binman.OsCommandAction"},
 		},
 	}
 

--- a/pkg/binman.go
+++ b/pkg/binman.go
@@ -69,6 +69,19 @@ func goSyncRepo(ghClient *github.Client, rel BinmanRelease, c chan<- BinmanMsg, 
 		}
 	}
 
+	actions = rel.setFinalActions()
+	if len(actions) > 0 {
+		log.Debugf("Performing %d final actions for %s", len(actions), rel.Repo)
+		for _, action := range actions {
+			err = action.execute()
+			if err != nil {
+				log.Debugf("Unable to complete task %s : %v", reflect.TypeOf(action), err)
+				c <- BinmanMsg{rel: rel, err: err}
+				return
+			}
+		}
+	}
+
 	c <- BinmanMsg{rel: rel, err: nil}
 }
 


### PR DESCRIPTION
@rjbrown57 

Add linking as the very last action that happens so that if there were any errors in either PostActions or OSActions that would cause binman to remove the repos as a cleanup step, the link still points to a valid release and not the cleaned (i.e. missing) release.