### PR TITLE
Verifyconfigadd

### DIFF
--- a/examples/extracefilenameExample.yaml
+++ b/examples/extracefilenameExample.yaml
@@ -1,0 +1,7 @@
+releases:
+ # systeroid a rust based alternative for sysctl contains a tar with two selectable binaries systeroid and systeroid-tui.
+ # Setting `extractfilename:systeoid-tui` will instruct binman to search for that file name in the extracted archive
+ # `linkname systeroid` will set the created link to systeroid instead of systeroid-tui   
+  - repo: orhun/systeroid
+    extractfilename: systeroid-tui
+    linkname: systeroid

--- a/pkg/config/main.go
+++ b/pkg/config/main.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 
 	binman "github.com/rjbrown57/binman/pkg"
+	gh "github.com/rjbrown57/binman/pkg/gh"
 	log "github.com/rjbrown57/binman/pkg/logging"
 	"gopkg.in/yaml.v3"
 )
@@ -52,6 +53,11 @@ func Add(config string, repo string) {
 	// We use NewGHBMConfig here to avoid grabbing contextual configs
 	currentConfig := binman.NewGHBMConfig(cPath)
 
+	err := gh.CheckRepo(gh.GetGHCLient(currentConfig.Config.TokenVar), repo)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
 	// Verify release is not present
 	if releasesContains(currentConfig.Releases, repo) {
 		log.Fatalf("%s is already present in %s", repo, cPath)
@@ -64,7 +70,7 @@ func Add(config string, repo string) {
 		log.Fatalf("Unable to marshal new config %s", err)
 	}
 
-	log.Infof("Adding %s to %s", repo, cPath)
+	log.Infof("Adding %s to %s. Latest version is ", repo, cPath)
 
 	// Write back
 	err = binman.WriteStringtoFile(cPath, string(newConfig))

--- a/pkg/config/main_test.go
+++ b/pkg/config/main_test.go
@@ -43,7 +43,7 @@ func TestReleasesContains(t *testing.T) {
 const testConfig = `
 config:
   releasepath: thereleasepath
-  tokenvar: thetoken
+  tokenvar: none # we set to 'none' here so ci based test will function
   upx:
     enabled: true
     args: []
@@ -52,7 +52,7 @@ releases:
 `
 
 func TestAdd(t *testing.T) {
-	var testRepo = "mytest/repo"
+	var testRepo = "rjbrown57/lp"
 
 	d := getTestDir(t)
 	defer os.Remove(d)

--- a/pkg/gh/repo.go
+++ b/pkg/gh/repo.go
@@ -1,0 +1,51 @@
+package gh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v50/github"
+)
+
+type BadRepoFormat struct {
+	repo string
+}
+
+func (e *BadRepoFormat) Error() string {
+	return fmt.Sprintf("%s should be in the format org/repo", e.repo)
+}
+
+type InvalidGhResponse struct {
+	resp *github.Response
+	err  error
+	repo string
+}
+
+func (e *InvalidGhResponse) Error() string {
+	return fmt.Sprintf("%s could not be verified - error %s - response %d", e.repo, e.err, e.resp.StatusCode)
+}
+
+// set project and org vars
+func getOR(repo string) (string, string) {
+	n := strings.Split(repo, "/")
+	return n[0], n[1]
+}
+
+func CheckRepo(ghClient *github.Client, repo string) error {
+
+	ctx := context.Background()
+
+	if !strings.Contains(repo, "/") {
+		return &BadRepoFormat{repo}
+	}
+
+	org, project := getOR(repo)
+
+	_, resp, err := ghClient.Repositories.GetLatestRelease(ctx, org, project)
+	if err != nil || resp.StatusCode > 200 {
+		return &InvalidGhResponse{resp, err, repo}
+	}
+
+	return nil
+}

--- a/pkg/gh/repo_test.go
+++ b/pkg/gh/repo_test.go
@@ -1,0 +1,42 @@
+package gh
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGetOr(t *testing.T) {
+
+	var testRepo string = "rjbrown57/binman"
+	org, proj := getOR(testRepo)
+
+	if org != "rjbrown57" || proj != "binman" {
+		t.Fatalf("repo not split correctly")
+	}
+}
+
+func TestCheckRepo(t *testing.T) {
+
+	// We use NewGHBMConfig here to avoid grabbing contextual configs
+
+	var tests = []struct {
+		Expected error
+		Got      error
+		Repo     string
+	}{
+		{Repo: "rjbrown57/binman", Expected: nil},
+		{Repo: "rjbrown57/binman_dne", Expected: &InvalidGhResponse{}},
+		{Repo: "rjbrown57badname", Expected: &BadRepoFormat{}},
+	}
+
+	for _, test := range tests {
+		test.Got = CheckRepo(GetGHCLient("none"), test.Repo)
+
+		if test.Expected != nil {
+			if errors.Is(test.Expected, test.Got) {
+				t.Fatalf("%s Expected \n%s \nGot \n%s", test.Repo, test.Expected, test.Got)
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
When using `binman config add org/repo` we now verify your input, and verify the repo exists + has releases we can query.