### PR TITLE
feat: use download worker pool to handle downloads

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,7 @@ config:
   releasepath:  #path to keep fetched releases. $HOME/binMan is the default
   tokenvar: #environment variable that contains github token
   cleanup: true # remove downloaded archive
+  maxdownloads: 10 # number of concurrent downloads allowed. Default is 3
   upx: #Compress binaries with upx
     enabled: false
     args: [] # arrary of args for upx
@@ -52,6 +53,7 @@ Top level `config:` options
 | key      | Description |
 | ----------- | ----------- |
 | cleanup   | Remove .zip/.tar files after we have extracted something. Useful in container builds / CI |
+| maxdownloads | number of concurrent downloads to allow. Default is number of releases |
 | releasepath | Path to publish files to |
 | tokenvar   | github token to use for auth. You can get yourself rate limited if you have a sizeable config. Instructions to [generate a token are here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token") |
 | upx   | config to enable upx shrinking. Details below |

--- a/examples/basicExample.yaml
+++ b/examples/basicExample.yaml
@@ -1,6 +1,7 @@
 config:
   #releasepath: /set/path/heretopublishto/ # Default is homeDirectory/binMan 
   tokenvar: GH_TOKEN # GITHUB API TOKEN
+  maxdownloads: 1 # maximum amount of concurent downloads. The default is the number of releases.
 releases:
   - repo: anchore/syft # Easy mode!
   - repo: google/go-containerregistry

--- a/pkg/binman.go
+++ b/pkg/binman.go
@@ -111,6 +111,13 @@ func Main(args map[string]string, debug bool, jsonLog bool, table bool, launchCo
 
 	go getSpinner(debug)
 
+	// start download workers
+	var numWorkers = config.Config.NumWorkers
+	log.Debugf("launching %d download workers", numWorkers)
+	for worker := 1; worker <= numWorkers; worker++ {
+		go getDownloader(worker)
+	}
+
 	relLength := len(releases)
 	log.Debugf("Process %v Releases", relLength)
 	swg.Add(1)
@@ -150,6 +157,8 @@ func Main(args map[string]string, debug bool, jsonLog bool, table bool, launchCo
 			log.Debugf("Final release data  %+v\n", msg.rel)
 		}
 	}
+
+	close(downloadChan)
 
 	swg.Add(1)
 	spinChan <- fmt.Sprintf("spinstop%s", setStopMessage(output))

--- a/pkg/downloader.go
+++ b/pkg/downloader.go
@@ -1,0 +1,26 @@
+package binman
+
+import (
+	"sync"
+
+	log "github.com/rjbrown57/binman/pkg/logging"
+)
+
+var downloadChan = make(chan dlMsg)
+
+// dlMsg is used to communicate with downloader pool
+type dlMsg struct {
+	url         string
+	filepath    string
+	wg          *sync.WaitGroup
+	confirmChan chan error
+}
+
+func getDownloader(id int) {
+	for msg := range downloadChan {
+		log.Debugf("downloader %d is handling %s\n", id, msg.url)
+		err := DownloadFile(msg.url, msg.filepath)
+		msg.confirmChan <- err
+		msg.wg.Done()
+	}
+}

--- a/pkg/downloader_test.go
+++ b/pkg/downloader_test.go
@@ -1,0 +1,48 @@
+package binman
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestGetDownloader(t *testing.T) {
+
+	var rWg sync.WaitGroup
+
+	badDl := dlMsg{
+		url:         "https://github.com/rjbrown57/binman/releases/download/vX.X.X/binman_linux_amd64",
+		filepath:    "/tmp/path1",
+		confirmChan: make(chan error, 1),
+		wg:          &rWg,
+	}
+
+	goodDl := dlMsg{
+		url:         "https://github.com/rjbrown57/binman/releases/download/v0.6.0/binman_linux_amd64",
+		filepath:    "/tmp/path1",
+		confirmChan: make(chan error, 1),
+		wg:          &rWg,
+	}
+
+	var tests = []struct {
+		testMsg dlMsg
+		err     error
+	}{
+		{badDl, fmt.Errorf("failed to download from https://github.com/rjbrown57/binman/releases/download/vX.X.X/binman_linux_amd64 - <nil> , 404")},
+		{goodDl, nil},
+	}
+
+	go getDownloader(1)
+
+	for _, test := range tests {
+		rWg.Add(1)
+		downloadChan <- test.testMsg
+		rWg.Wait()
+		close(test.testMsg.confirmChan)
+
+		err := <-test.testMsg.confirmChan
+		if err != nil && err.Error() != test.err.Error() {
+			t.Fatalf("got %v - expected %v\n", err, test.err)
+		}
+	}
+}

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -47,10 +47,11 @@ type UpxConfig struct {
 
 // BinmanConfig contains Global Config Options
 type BinmanConfig struct {
-	CleanupArchive bool      `yaml:"cleanup,omitempty"`     // mark true if archive should be cleaned after extraction
-	ReleasePath    string    `yaml:"releasepath,omitempty"` //path to download/link releases from github
-	TokenVar       string    `yaml:"tokenvar,omitempty"`    //Github Auth Token
-	UpxConfig      UpxConfig `yaml:"upx,omitempty"`         // Allow upx to shrink extracted
+	CleanupArchive bool      `yaml:"cleanup,omitempty"`      // mark true if archive should be cleaned after extraction
+	ReleasePath    string    `yaml:"releasepath,omitempty"`  // path to download/link releases from github
+	TokenVar       string    `yaml:"tokenvar,omitempty"`     // Github Auth Token
+	NumWorkers     int       `yaml:"maxdownloads,omitempty"` // maximum number of concurrent downloads the user will allow
+	UpxConfig      UpxConfig `yaml:"upx,omitempty"`          // Allow upx to shrink extracted
 }
 
 // BinmanDefaults contains default config options. If a value is unset in releases array these will be used.
@@ -187,6 +188,10 @@ func (config *GHBMConfig) setDefaults() {
 			log.Fatalf("Unable to detect home directory %v", err)
 		}
 		config.Config.ReleasePath = hDir + "/binMan"
+	}
+
+	if config.Config.NumWorkers == 0 {
+		config.Config.NumWorkers = len(config.Releases)
 	}
 
 	if config.Config.TokenVar == "" {


### PR DESCRIPTION
Allow setting of max # of downloads to occur at once. Will default to previous behavior of allowing as many downloads as releases.

closes https://github.com/rjbrown57/binman/issues/68