### PR TITLE
refactor: add source + identify if querying latest in metrics for watch

### DIFF
--- a/pkg/preactions.go
+++ b/pkg/preactions.go
@@ -33,7 +33,11 @@ func (action *ReleaseStatusAction) execute() error {
 	_, err := os.Stat(action.r.publishPath)
 
 	if action.r.watchExposeMetrics {
-		action.r.metric.WithLabelValues("true", action.r.Repo, action.r.Version)
+		var latestLabel string = "true"
+		if action.r.QueryType == "releasebytag" {
+			latestLabel = "false"
+		}
+		action.r.metric.WithLabelValues(latestLabel, action.r.SourceIdentifier, action.r.Repo, action.r.Version)
 	}
 
 	// If err nil we already have this version, send custom error so gosyncrepo knows to end actions

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -279,7 +279,7 @@ func (config *GHBMConfig) setWatchConfig() {
 		config.Config.Watch.Frequency = 60
 	}
 
-	config.metrics = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "binman_release"}, []string{"latest", "repo", "version"})
+	config.metrics = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "binman_release"}, []string{"latest", "source", "repo", "version"})
 
 	config.populateReleases()
 }


### PR DESCRIPTION
Changes for watch mode around metrics
* Add sourceIdentifier to metric
* Update latest label to be false if version was queried by tag