### PR TITLE
feat: add templating to arch and os config fields

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -47,12 +47,12 @@ These options can be set per release
 
 | key      | Description |
 | ----------- | ----------- |
-| arch   | target architecture |
+| arch   | target architecture (can be templated similar to [externalurl](../docs/external_urls.md)) |
 | cleanup   | Remove .zip/.tar files after we have extracted something. Useful in container builds / CI |
 | downloadonly   | default `false`. Set to true if you don't want binman to try to extract and link the asset |
 | externalurl | see [externalurl support](../docs/external_urls.md) |
 | linkname | by default binman will create a symlink matching the project name. This can be overridden with linkname set per release |
-| os | target OS  |
+| os | target OS (can be templated similar to [externalurl](../docs/external_urls.md)) |
 | releasefilename | in some cases project publish assets that have different names than the github project. For example [cilium-cli](github.com/cilium/cilium-cli) publishes a cli `cilium`. We would set `cilium` here so binman knows what to look for |
 | releasepath | Alternate releasepath from what is set in the main config |
 | source | git source to get release from. By default set to "github.com". Must match the name key of a configured source. See [config-sources](#config-sources)


### PR DESCRIPTION
Allow the `arch` and `os` fields in the config file to be templated. This is a bit of a hack considering that we have to override the Data Map with the default GOOS and GOARCH in order to get it to work. But it allows users to override specific fields instead of having to specify the entire ExternalURL if their project of choice does something odd with the Arch or OS fields.

Examples I've used it for:

```
  # A k9s-esque application for viewing Cloud resources from AWS or GCP
  - repo: one2nc/cloudlens
    arch: '{{ if eq .os "darwin" }}all{{ else }}{{ .arch }}{{ end }}'
  # A slightly more robust and easy to use tool than sed for replacing text in files
  - repo: your-tools/ruplacer
    os: '{{ if eq .os "darwin" }}apple-darwin{{ else if eq .os "linux" }}unknown-linux{{ else }}pc-windows{{ end }}'
    arch: '{{ if eq .os "darwin"}}aarch64{{ else }}{{ .arch }}{{ end }}'
```