### PR TITLE
feat: add support for excluding OS

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -60,6 +60,7 @@ These options can be set per release
 | version | pin to a specific release version |
 | postcommands | see [post commands](../docs/postcommands.md)|
 | postonly | only run [post commands](../docs/postcommands.md) after we have checked for new versions. This allows binman to trigger apt/yum/brew or something like that |
+| excludeos | list of Operating Systems to exclude this release from, useful when you know there are certain OS's that a specific repo doesn't support so you don't get an error |
 
 ## Binman Config subcommand
 

--- a/internal/main.go
+++ b/internal/main.go
@@ -61,12 +61,16 @@ func Main(bm *BMConfig) error {
 			continue
 		}
 
-		// Todo create an error here and use errors.Is
-		if msg.Err.Error() == "Noupdate" {
+		switch msg.Err.(type) {
+		case *NoUpdateError:
 			output["Up to Date"] = append(output["Up to Date"], msg)
 			continue
+		case *ExcludeError:
+			continue
+		default:
+			// Todo create an error here and use errors.Is
+			output["Error"] = append(output["Error"], msg)
 		}
-		output["Error"] = append(output["Error"], msg)
 	}
 
 	bm.OutputOptions.SendSpin(fmt.Sprintf("spinstop%s", SetStopMessage(output)))

--- a/pkg/actions_test.go
+++ b/pkg/actions_test.go
@@ -93,33 +93,33 @@ func TestSetPreActions(t *testing.T) {
 		{
 			"relwithoutpublish",
 			relWithOutPublish.setPreActions("/tmp/", "/tmp/"),
-			[]string{"*binman.GetGHReleaseAction", "*binman.ReleaseStatusAction", "*binman.SetUrlAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
+			[]string{"*binman.ReleaseExcludeAction", "*binman.GetGHReleaseAction", "*binman.ReleaseStatusAction", "*binman.SetUrlAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
 		},
 		{
 			// this release has a preset publish path this means it's a binman get and we don't need to use releasestatusaction
 			"relWithPublish",
 			relWithPublish.setPreActions("/tmp/", "/tmp/"),
-			[]string{"*binman.GetGHReleaseAction", "*binman.SetUrlAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
+			[]string{"*binman.ReleaseExcludeAction", "*binman.GetGHReleaseAction", "*binman.SetUrlAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
 		},
 		{
 			"relQueryByTag",
 			relQueryByTag.setPreActions("/tmp/", "/tmp/"),
-			[]string{"*binman.GetGHReleaseAction", "*binman.SetUrlAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
+			[]string{"*binman.ReleaseExcludeAction", "*binman.GetGHReleaseAction", "*binman.SetUrlAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
 		},
 		{
 			"relPostOnly",
 			relPostOnly.setPreActions("/tmp/", "/tmp/"),
-			[]string{"*binman.GetGHReleaseAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
+			[]string{"*binman.ReleaseExcludeAction", "*binman.GetGHReleaseAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
 		},
 		{
 			"relExternalUrl",
 			relExternalUrl.setPreActions("/tmp/", "/tmp/"),
-			[]string{"*binman.GetGHReleaseAction", "*binman.ReleaseStatusAction", "*binman.SetUrlAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
+			[]string{"*binman.ReleaseExcludeAction", "*binman.GetGHReleaseAction", "*binman.ReleaseStatusAction", "*binman.SetUrlAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
 		},
 		{
 			"relGLBasic",
 			relGLBasic.setPreActions("/tmp/", "/tmp"),
-			[]string{"*binman.GetGLReleaseAction", "*binman.ReleaseStatusAction", "*binman.SetUrlAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
+			[]string{"*binman.ReleaseExcludeAction", "*binman.GetGLReleaseAction", "*binman.ReleaseStatusAction", "*binman.SetUrlAction", "*binman.SetArtifactPathAction", "*binman.SetPostActions"},
 		},
 	}
 

--- a/pkg/binman.go
+++ b/pkg/binman.go
@@ -36,8 +36,11 @@ func goSyncRepo(rel BinmanRelease, c chan<- BinmanMsg, wg *sync.WaitGroup) {
 
 	for rel.actions != nil {
 		if err = rel.runActions(); err != nil {
-			switch err.Error() {
-			case "Noupdate":
+			switch err.(type) {
+			case *NoUpdateError:
+				c <- BinmanMsg{Rel: rel, Err: err}
+				return
+			case *ExcludeError:
 				c <- BinmanMsg{Rel: rel, Err: err}
 				return
 			default:

--- a/pkg/binmanRelease.go
+++ b/pkg/binmanRelease.go
@@ -22,6 +22,24 @@ var (
 	ErrNoVersionsFound = errors.New("No Versions detected for release")
 )
 
+type NoUpdateError struct {
+	RepoName string
+	Version  string
+}
+
+func (e *NoUpdateError) Error() string {
+	return fmt.Sprintf("%s is already at %s version, nothing to do here", e.RepoName, e.Version)
+}
+
+type ExcludeError struct {
+	RepoName string
+	Criteria string
+}
+
+func (e *ExcludeError) Error() string {
+	return fmt.Sprintf("%s was excluded from consideration because: %s", e.RepoName, e.Criteria)
+}
+
 // BinmanRelease contains info on specifc releases to hunt for
 type BinmanRelease struct {
 	Os               string        `yaml:"os,omitempty"`
@@ -44,6 +62,7 @@ type BinmanRelease struct {
 	SourceIdentifier string        `yaml:"source,omitempty"`      // Allow setting of source individually
 	PublishPath      string        `yaml:"publishpath,omitempty"` // Path Release will be set up at. Typically only set by set commands or library use.
 	ArtifactPath     string        `yaml:"-"`                     // Will be set by BinmanRelease.setPaths. This is the source path for the link aka the executable binary
+	ExcludeOs        []string      `yaml:"excludeos,omitempty"`   // Allows excluding certain OS's because we know that we'll never have releases for this OS
 
 	createdAtTime    int64 // Unix time that release was created at
 	metric           *prometheus.GaugeVec

--- a/pkg/preactions_test.go
+++ b/pkg/preactions_test.go
@@ -1,6 +1,7 @@
 package binman
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,7 +46,8 @@ func TestReleaseStatusAction(t *testing.T) {
 		t.Fatalf("Expected no error, got %s", err)
 	}
 
-	if err = rNoUpdate.AddReleaseStatusAction(d).execute(); err != nil && err.Error() != "Noupdate" {
+	noUpErr := &NoUpdateError{}
+	if err = rNoUpdate.AddReleaseStatusAction(d).execute(); err != nil && !errors.As(err, &noUpErr) {
 		t.Fatalf("Expected no error, got %s", err)
 	}
 


### PR DESCRIPTION
Allows the user to specify a list of excluded OS's for a given release. Which is particularly useful for avoiding errors when repos don't support a specific OS.

Not sure what you'll think of this one, feel free to reject it if you don't like the changes, or would prefer this to be done a different way.

I also changed common error types to be evaluated by an actual Error interfaces rather than their message strings to make the pattern a bit more extensible and so that people didn't have to guess where error strings were being evaluated.