### PR TITLE
fix: return error when no versions exist

### DIFF
--- a/pkg/clean.go
+++ b/pkg/clean.go
@@ -116,8 +116,17 @@ func sortSemvers(versions []string) ([]string, error) {
 func (r *BinmanRelease) getVersions(bdb *bolt.DB) error {
 	return bdb.View(func(tx *bolt.Tx) error {
 		sourceBucket := tx.Bucket([]byte(r.SourceIdentifier))
+		if sourceBucket == nil {
+			return fmt.Errorf("no versions stored for source %s", r.SourceIdentifier)
+		}
 		orgBucket := sourceBucket.Bucket([]byte(r.org))
+		if orgBucket == nil {
+			return fmt.Errorf("no versions stored for org %s/%s", r.SourceIdentifier, r.org)
+		}
 		projBucket := orgBucket.Bucket([]byte(r.project))
+		if projBucket == nil {
+			return fmt.Errorf("no versions stored for %s/%s/%s", r.SourceIdentifier, r.org, r.project)
+		}
 		projBucket.ForEachBucket(func(k []byte) error {
 			version := string(k)
 			_, err := semver.NewVersion(version)


### PR DESCRIPTION
I originally ran a clean on one of my lesser used machines and it resulted in the following nil pointer error:

```
% binman clean
INFO[0000] Binman Clean started
...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x10 pc=0x10086c604]

goroutine 1 [running]:
go.etcd.io/bbolt.(*Bucket).Bucket(0x0, {0x44afca05b510, 0x8, 0x1008764b0?})
        /home/runner/go/pkg/mod/go.etcd.io/bbolt@v1.4.3/bucket.go:89 +0x24
github.com/rjbrown57/binman/pkg.Clean.(*BinmanRelease).getVersions.func1(0x44afca15ad20)
        /home/runner/work/binman/binman/pkg/clean.go:120 +0x98
go.etcd.io/bbolt.(*DB).View(0x102580a40?, 0x44afca05b928)
        /home/runner/go/pkg/mod/go.etcd.io/bbolt@v1.4.3/db.go:939 +0x68
github.com/rjbrown57/binman/pkg.(*BinmanRelease).getVersions(...)
        /home/runner/work/binman/binman/pkg/clean.go:117
github.com/rjbrown57/binman/pkg.Clean(0x0, 0x0, 0x3, {0x0, 0x0}, {0x0, 0x0})
        /home/runner/work/binman/binman/pkg/clean.go:50 +0x284
github.com/rjbrown57/binman/cmd.init.func7(0x44afca1d4f00?, {0x101438613?, 0x4?, 0x101438617?})
        /home/runner/work/binman/binman/cmd/clean.go:30 +0x168
github.com/spf13/cobra.(*Command).execute(0x102584be0, {0x1025bf8e0, 0x0, 0x0})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1019 +0x7fc
github.com/spf13/cobra.(*Command).ExecuteC(0x1025851a0)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
github.com/rjbrown57/binman/cmd.Execute()
        /home/runner/work/binman/binman/cmd/root.go:36 +0x24
main.main()
        /home/runner/work/binman/binman/main.go:11 +0x1c
```

I believe that this happens because there are entries in my config that may not have any version history because they were not able to be downloaded for this machines architecture.

Added nil guards and tested it out, and it just emits an error instead of crashing.